### PR TITLE
Bugfix failing User storage and improved logging severity

### DIFF
--- a/server/src/app.hooks.ts
+++ b/server/src/app.hooks.ts
@@ -195,8 +195,16 @@ const purgeErrors = (context: HookContext):void => {
 };
 
 const logErrors = (context: HookContext):void => {
-    const message = [context.error.name, 'from app.hooks.ts:', context.error.message, 'during', context.method, context.path].join(' ');
-    logger.error(message);
+    const { error, method, path } = context;
+    const expectedErrors = ['ForbiddenError','NotFound','NotAuthenticated'];
+
+    const message = [error.name, 'from app.hooks.ts:', error.message, 'during', method, path].join(' ');
+
+    if(expectedErrors.includes(error.name)) {
+        logger.warn(message);
+    } else {
+        logger.error(message);
+    }
 };
 
 const syncToFirestore = async (context: HookContext):Promise<HookContext> => {

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,4 +1,4 @@
-import winston, { format, createLogger, transports } from 'winston';
+import { format, createLogger, transports } from 'winston';
 import { LoggingWinston } from '@google-cloud/logging-winston';
 
 const isLocalEnvironment = process.env.VOTE_HOSTNAME?.includes('localhost');
@@ -37,7 +37,7 @@ const stackdriverLogger = new LoggingWinston({
     },
 });
 
-const logger = winston.createLogger({
+const logger = createLogger({
     level: loggingLevel,
     format: format.combine(
         format.json(),

--- a/server/test/authentication.ts
+++ b/server/test/authentication.ts
@@ -70,4 +70,23 @@ describe('Authentication', async () => {
             assert.fail(`User was not saved correctly ${error}`);
         }
     });
+
+    it('User logged in before without saved user gets stored', async () => {
+        await app.services.user.remove('54512',{});
+        
+        try {
+            const jwtPayload: Record<string, any> = {
+                'https://login.bcc.no/claims/personId': 54512,
+                iat: Date.now() - (60000) //1 minute ago
+            };
+
+            const authenticatedUser = await getUserBasedOnPayLoad(jwtPayload, app);
+            assert.equal(jwtPayload.iat, authenticatedUser.authTime);
+            
+            const savedUser = await app.services.user.get(authenticatedUser._key,{}) as User;
+            assert.equal(jwtPayload.iat, savedUser.authTime);
+        } catch (error) {
+            assert.fail(`User was not saved correctly ${error}`);
+        }
+    });
 });


### PR DESCRIPTION
Closes #372 and closes [#1933](https://github.com/bcc-code/bcc-membership/issues/1993)

There was a bug in the system where users where not being saved to the Vote db. This was implemented because of a previous bugfix where users where being saved each time they where authenticated.

Also some expected errors are now logged with the 'warning' severity.

The Users that where not stored should be querried and readded to the vote db to fix the report incident: 

['24271','21483','17262','25824','12058','28997','25623','17443','36470','30094','16912','12065','16201','23737','45434','17420','33887','23589','24416','34933','18103','23081','16523','12060','10265','16518','25177','16857','12084','27723','24272']

['16859','18103','17443','12060','30094','16201','17420','12065','12084','16518','36470','12058','24272','23081','14652','25824','17262','23589','16912','10265','33887','21483','42116','45434','23737','28997','16857','24271','16523','45311','25177','34933','25623','30095','10195','45433']

```
FOR u IN person
    FILTER u._key IN ['54512']
    
RETURN {
    _id: u._id,
    _key: u._key,
    displayName: u.displayName,
    personID: u.personID,
    churchName: u.church.name,
    churchID: u.churchID,
    activeRole: 'Member',
    administrator: u.administrator,
    email: u.email,
    roles: u.related.roles,
    age: u.age,
    cellPhone: u.cellPhone,
}
```
Query for getting the missing users.